### PR TITLE
`Base.Pair === Core.Compiler.Pair` on 1.7

### DIFF
--- a/src/patches.jl
+++ b/src/patches.jl
@@ -97,7 +97,7 @@ Base.getindex(ref::UseRef) = Core.Compiler.getindex(ref)
 Base.iterate(uses::UseRefIterator) = Core.Compiler.iterate(uses)
 Base.iterate(uses::UseRefIterator, st) = Core.Compiler.iterate(uses, st)
 
-@static if VERSION < v"1.8-"
+@static if VERSION < v"1.7-"
 Base.iterate(p::Core.Compiler.Pair) = Core.Compiler.iterate(p)
 Base.iterate(p::Core.Compiler.Pair, st) = Core.Compiler.iterate(p, st)
 end


### PR DESCRIPTION
Here's the corresponding PR: https://github.com/JuliaLang/julia/pull/41659.
These methods were pirating the definitions on stable Julia and (among other things) causing precompilation to fail.