### PR TITLE
Continuation of Roger's fix for v1.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
+          - '1'
           - '1.6'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ Expronicon = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3636"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 
 [compat]
-Expronicon = "0.6"
+Expronicon = "0.10"
 MLStyle = "0.4"
 julia = "1.6"
 

--- a/src/CompilerPluginTools.jl
+++ b/src/CompilerPluginTools.jl
@@ -16,7 +16,6 @@ export
     SSAValue,
     Const,
     PartialStruct,
-    Slot,
     GotoIfNot,
     GotoNode,
     SlotNumber,
@@ -71,7 +70,6 @@ using Core:
     SSAValue,
     Const,
     PartialStruct,
-    Slot,
     GotoIfNot,
     GotoNode,
     SlotNumber,
@@ -134,6 +132,11 @@ using Core.Compiler:
     verify_ir,
     retrieve_code_info,
     slot2reg
+
+@static if VERSION < v"1.10-"
+    export Slot
+    using Core: Slot
+end
 
 include("compat.jl")
 include("utils.jl")

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -12,7 +12,12 @@ The default julia optimization pass.
 """
 function default_julia_pass(ir::IRCode, sv::OptimizationState)
     ir = compact!(ir)
-    ir = ssa_inlining_pass!(ir, ir.linetable, sv.inlining, sv.src.propagate_inbounds)
+    if VERSION < v"1.9-"
+        ir = ssa_inlining_pass!(ir, ir.linetable, sv.inlining, sv.src.propagate_inbounds)
+    else
+        ir = ssa_inlining_pass!(ir, sv.inlining, ci.propagate_inbounds)
+    end
+
     ir = compact!(ir)
 
     @static if VERSION < v"1.8-"

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -15,7 +15,7 @@ function default_julia_pass(ir::IRCode, sv::OptimizationState)
     if VERSION < v"1.9-"
         ir = ssa_inlining_pass!(ir, ir.linetable, sv.inlining, sv.src.propagate_inbounds)
     else
-        ir = ssa_inlining_pass!(ir, sv.inlining, ci.propagate_inbounds)
+        ir = ssa_inlining_pass!(ir, sv.inlining, sv.src.propagate_inbounds)
     end
 
     ir = compact!(ir)

--- a/src/patches.jl
+++ b/src/patches.jl
@@ -82,12 +82,11 @@ end
 end
 
 # move this to Base?
-@static if VERSION < v"1.9-"
-    Base.iterate(ic::Core.Compiler.IncrementalCompact) = Core.Compiler.iterate(ic)
-    Base.iterate(ic::Core.Compiler.IncrementalCompact, st) = Core.Compiler.iterate(ic, st)
-    Base.getindex(ic::Core.Compiler.IncrementalCompact, idx) = Core.Compiler.getindex(ic, idx)
-    Base.setindex!(ic::Core.Compiler.IncrementalCompact, v, idx) = Core.Compiler.setindex!(ic, v, idx)
-end
+Base.iterate(ic::Core.Compiler.IncrementalCompact) = Core.Compiler.iterate(ic)
+Base.iterate(ic::Core.Compiler.IncrementalCompact, st) = Core.Compiler.iterate(ic, st)
+Base.getindex(ic::Core.Compiler.IncrementalCompact, idx) = Core.Compiler.getindex(ic, idx)
+Base.setindex!(ic::Core.Compiler.IncrementalCompact, v, idx) = Core.Compiler.setindex!(ic, v, idx)
+
 
 Base.getindex(ic::Core.Compiler.Instruction, idx) = Core.Compiler.getindex(ic, idx)
 Base.setindex!(ic::Core.Compiler.Instruction, v, idx) = Core.Compiler.setindex!(ic, v, idx)

--- a/src/patches.jl
+++ b/src/patches.jl
@@ -82,10 +82,12 @@ end
 end
 
 # move this to Base?
-Base.iterate(ic::Core.Compiler.IncrementalCompact) = Core.Compiler.iterate(ic)
-Base.iterate(ic::Core.Compiler.IncrementalCompact, st) = Core.Compiler.iterate(ic, st)
-Base.getindex(ic::Core.Compiler.IncrementalCompact, idx) = Core.Compiler.getindex(ic, idx)
-Base.setindex!(ic::Core.Compiler.IncrementalCompact, v, idx) = Core.Compiler.setindex!(ic, v, idx)
+@static if VERSION < v"1.9-"
+    Base.iterate(ic::Core.Compiler.IncrementalCompact) = Core.Compiler.iterate(ic)
+    Base.iterate(ic::Core.Compiler.IncrementalCompact, st) = Core.Compiler.iterate(ic, st)
+    Base.getindex(ic::Core.Compiler.IncrementalCompact, idx) = Core.Compiler.getindex(ic, idx)
+    Base.setindex!(ic::Core.Compiler.IncrementalCompact, v, idx) = Core.Compiler.setindex!(ic, v, idx)
+end
 
 Base.getindex(ic::Core.Compiler.Instruction, idx) = Core.Compiler.getindex(ic, idx)
 Base.setindex!(ic::Core.Compiler.Instruction, v, idx) = Core.Compiler.setindex!(ic, v, idx)

--- a/src/typeinf.jl
+++ b/src/typeinf.jl
@@ -12,8 +12,14 @@ return ret
 ```
 """
 function typeinf_lock(f)
-    ccall(:jl_typeinf_begin, Cvoid, ())
-    ret = f()
-    ccall(:jl_typeinf_end, Cvoid, ())
+    @static if VERSION < v"1.9-"
+        ccall(:jl_typeinf_begin, Cvoid, ())
+        ret = f()
+        ccall(:jl_typeinf_end, Cvoid, ())
+    else
+        ccall(:jl_typeinf_timing_begin, Cvoid, ())
+        ret = f()
+        ccall(:jl_typeinf_timing_end, Cvoid, ())
+    end
     return ret
 end

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -32,5 +32,5 @@ dummy(x) = 2x
     ic = IncrementalCompact(ir)
     (_, idx), stmt = first(ic)
     @test idx == 1
-    ic[1]
+    ic[SSAValue(1)]
 end


### PR DESCRIPTION
Hello @Roger-luo, I need to relax the requirement for `Expronicon.jl` in this package as well since it's required in `ZXCalculus.jl`'s testing.

I tested on your branch for fixes for v1.9. There was another error regarding [getindex](https://github.com/JuliaLang/julia/commit/3d2c9b7eabb30870aa653d7ad6782c44bafe994f) for `IncrementalCompact`. It no longer supports getting by `Int`, you have to do it through `SSAValue` or `OldSSAValue`. I modified the corresponding code in the test to do what the previous code does. Test passed with no problem. 

Let me know if you would like to see some other changes. If possible, could you please bump the version so that `ZXCalculus.jl` could use the latest version? Thanks a lot!