### PR TITLE
Tag a release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CompilerPluginTools"
 uuid = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3638"
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 Expronicon = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3636"


### PR DESCRIPTION
The current version of master successfully precompiles on 1.10-rc1, but version 0.1.9 does not. This is making ensuring that Umlaut.jl works on 1.10 a little tricky, as we have to dev this package to guarantee that it does, meaning that we can't create a release which we believe will work on 1.10.

Is there any chance that we could cut a release in anticipation of 1.10 being released, or are we holding off for some reason?